### PR TITLE
Clarify roles of issues, commits, and PRs

### DIFF
--- a/.claude/AGENTS.md
+++ b/.claude/AGENTS.md
@@ -1,5 +1,22 @@
 # Agent Protocols
 
+## The change lifecycle
+
+Every change flows through the same pipeline, and each artifact has exactly **one job**:
+
+```
+idea → issue → commit → PR → review → merge
+```
+
+- **Issue** — the single source of truth for *intent*: why the change is wanted and the acceptance criteria that define "done". Issues are the mechanism that produces commits (and therefore PRs).
+- **Commit** — the single source of truth for the *change itself*: what shipped and why it was done this way. It must stand entirely on its own (see GIT_STANDARDS.md).
+- **PR** — purely a *mechanism for review*. Its description and discussion serve the review; they are not the historical record. A PR is **never** an SSOT — anything that must outlive the review belongs in a commit.
+
+Two consequences fall out of this:
+
+- **Trivial changes may skip the issue** and go straight to a commit/PR.
+- **One PR does not mean one issue.** A single PR may bundle several commits and close several issues; conversely a single issue may span several commits. The mapping is flexible — don't fragment issues, commits, or PRs just to keep them one-to-one.
+
 ## Standards files
 
 Do NOT read these files upfront. Read them on demand when the task requires it:

--- a/.claude/GIT_STANDARDS.md
+++ b/.claude/GIT_STANDARDS.md
@@ -1,5 +1,7 @@
 # Git Standards
 
+The commit message is the **single source of truth for the change**: what shipped and why it was done this way. It must stand entirely on its own — a reader of `git log` years from now must understand the rationale without opening the linked issue or PR. Issue/PR links are conveniences, never required reading. The PR is only a review mechanism and is never the source of truth (see the change lifecycle in AGENTS.md). If a piece of context matters for the future, it belongs in the commit body, not the PR description.
+
 When creating commits, follow [Tim Pope's commit message guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html). The key rules are:
 
 ## Subject line
@@ -13,6 +15,7 @@ When creating commits, follow [Tim Pope's commit message guidelines](https://tba
 - Separated from the subject by a **single blank line**
 - **Wrap at 72 characters**
 - Focus on **why** the change was made, not what (the diff shows what)
+- Make it **self-contained**: include enough context that the reader never has to open the linked issue or PR to understand why. Distill the relevant intent from the issue into the body rather than pointing at it.
 - If the explanation needs more than two paragraphs, add a bulleted TLDR summary at the top of the body
 
 ## Footer

--- a/.claude/ISSUE_STANDARDS.md
+++ b/.claude/ISSUE_STANDARDS.md
@@ -1,5 +1,7 @@
 # Issue Standards
 
+An issue is the **single source of truth for *intent*** — why a change is wanted and the acceptance criteria that define "done". It is the mechanism that produces commits and PRs; it does not record the change itself (that is the commit's job). See the change lifecycle in AGENTS.md for how issues, commits, and PRs relate.
+
 ## Issue Classification & Selection
 
 When the user's request involves creating a GitHub issue, you MUST classify it into exactly one of the following types and select the corresponding Issue Type when prompted:
@@ -20,6 +22,28 @@ The vast majority of tickets should be **DEFECT**, **FEATURE**, or **TASK**. Def
 - **Use EPIC only** when the work clearly spans multiple distinct Features/Tasks that need to be tracked together under a shared goal.
 - **Use INITIATIVE only** when coordinating multiple Epics toward a strategic objective — this is rare and typically driven by leadership or long-range planning.
 - When in doubt, create a FEATURE or TASK with a narrow, well-defined scope. If it later becomes clear that the work is part of something bigger, promote it then.
+
+### No meta-tickets
+
+Since an issue's only job is to carry *intent*, every issue must add intent of its own. A **meta-ticket** — an issue whose only purpose is to group or point at other issues without contributing its own description or acceptance criteria — adds nothing and is just noise. Do not create them. Before creating any "umbrella" or "tracking" ticket, ask whether it carries its own substance (a distinct description, its own acceptance criteria). If not, drop it and let each ticket stand on its own.
+
+- **Each ticket must stand on its own.** A handful of related fixes do not need a parent to tie them together — create them as independent DEFECT/FEATURE/TASK tickets, each with a well-defined scope.
+- **Don't fragment issues to mirror PRs or commits.** One PR may close several issues, and one issue may span several commits (see the change lifecycle in AGENTS.md). Never invent an extra parent/umbrella issue just to bundle work that will ship together — the PR is the bundle, and the commits are the record. Conversely, don't split work into separate PRs just because it touches separate issues.
+
+### Parent / sub-issue relationships
+
+Parent ↔ sub-issue links are fine, but **only** when the parent carries real intent of its own and the split serves an organizational purpose:
+
+- **The parent is the SSOT of intent for the grouped work.** The parent ticket holds the description and defines the acceptance criteria. Sub-issues exist to break the work into chunks that can be implemented incrementally or in parallel by multiple devs, and to make that progress visible on the kanban board.
+- **Sub-issues are organizational proxies and carry no Issue Type.** They exist purely for visibility on the kanban board; the parent (typically a FEATURE or EPIC) remains the source of truth that defines the ACs. Do not duplicate or fragment the acceptance criteria across the sub-issues.
+- **If the parent adds nothing, remove it.** When the would-be parent has no intent of its own and every sub-ticket can stand alone, delete the parent and keep the standalone tickets.
+
+### Classify by the actual problem
+
+Choose the Issue Type that matches what the ticket really describes, so the template's sections fit the content:
+
+- A ticket describing a **correctness issue** (something behaving incorrectly) is a **DEFECT**, even if it was first framed as a generic task. As a DEFECT, its Observed/Expected Behavior sections capture the problem cleanly.
+- Watch for a misclassified ticket whose "Why?" section is really just describing observed-vs-expected behavior — that is a signal it should be a DEFECT rather than a FEATURE/TASK.
 
 ### Other rules
 

--- a/.claude/PR_STANDARDS.md
+++ b/.claude/PR_STANDARDS.md
@@ -1,13 +1,23 @@
 # Pull Request Standards
 
+## What a PR is for
+
+A pull request is a **mechanism for review**, nothing more. Its description and discussion exist to help reviewers understand and evaluate the change — they are not the historical record. The durable rationale for *why* a change was made lives in the commit message(s), which are the single source of truth for the change (see GIT_STANDARDS.md and the change lifecycle in AGENTS.md). A PR is **never** an SSOT: if something matters for the future, it belongs in a commit, not the PR description.
+
+Because the PR only serves the review, its description is a **short executive summary** aimed at reviewers — not a record to be mined later, and not a copy of the commit messages. A PR may bundle several commits and close several issues; one PR does not mean one issue.
+
 ## Pull Request Template
 
 When creating a pull request, the PR body MUST be copied **verbatim** from the template below — including all section headings, checkbox lists (`- [ ]`), and formatting. Only the HTML comments are replaced with actual content:
 
 ~~~markdown
 <!-- ---------------------------------------------------------------------------
-Briefly describe what the Pull Request changes or adds. If the pull request is
-related to any GitHub issues, link them like this:
+Write a SHORT executive summary of what the Pull Request changes or adds — ideally
+one paragraph, at most two. This is a high-level summary for reviewers, NOT a copy
+of the commit messages or a per-commit changelog. Explain the overall change and
+why it matters, not every individual step.
+
+If the pull request is related to any GitHub issues, link them like this:
 
 Closes: #123, #456
 ---------------------------------------------------------------------------- -->
@@ -39,7 +49,7 @@ Add "N/A" if there is no additional information.
 
 When filling out the PR template:
 
-- Write a clear description at the top explaining what the PR changes and why.
+- Write a SHORT executive summary at the top — one or two paragraphs max — explaining what the PR changes and why. It must be a concise high-level summary, NOT a copy of the commit messages or a per-commit breakdown.
 - Link related issues using `Closes: #NNN` syntax.
 - Check the appropriate compliance boxes based on the nature of the changes.
 - Check the testing confirmation boxes only if testing was actually performed.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,13 @@
 <!-- ---------------------------------------------------------------------------
-Please briefly describe what your Pull Request changes or adds. If your pull
-request is related to any GitHub issues, please link them below, like this:
+Please write a SHORT executive summary of what your Pull Request changes or adds
+— ideally one paragraph, at most two. This is a high-level summary for reviewers,
+NOT a copy of the commit messages or a per-commit changelog. Explain the overall
+change and why it matters, not every individual step.
+
+If your pull request is related to any GitHub issues, please link them below,
+like this:
 
 Closes: #123, #456
-
-In case you have created this PR with a proper commit message following our
-commit guidelines, GitHub should have automatically added the commit message
-above this placeholder.
 ---------------------------------------------------------------------------- -->
 
 ## PR Compliance


### PR DESCRIPTION
Aligns the agent standards files around one model for how issues, commits, and PRs relate, so their purposes stop blurring together. Each artifact now has a single, explicit job: the **commit** is the source of truth for the change (self-contained, why-focused), the **issue** is the source of truth for intent (the why and acceptance criteria), and the **PR** is purely a mechanism for review — never a place of record. The `idea → issue → commit → PR → review → merge` lifecycle is documented once in AGENTS.md as the canonical overview, and each standards file now covers only its own slice and links back to it.

Concretely this adds the lifecycle section to AGENTS.md, the "no meta-tickets" / parent–sub-issue / classification guidance to ISSUE_STANDARDS.md, the "what a PR is for" framing plus executive-summary rule to PR_STANDARDS.md and the PR template, and the self-contained-commit rule to GIT_STANDARDS.md. Documentation only — no code changes.

## PR Compliance

**Please select all that apply (zero or more):**

- [x] This PR **adds new or improves** existing functionality *(Feature, Task)*
- [ ] This PR **fixes** something that was not working correctly *(Defect)*
- [ ] The changes in this PR are **not** backwards compatible *(Breaking Change)*


**Required: Please confirm you have completed the following testing steps:**

- [x] I hereby confirm that **I have tested the changes manually** and they work as expected
- [x] I hereby confirm that **I have added/updated tests** that cover the changes in this PR where necessary


## Additional Information

Documentation-only change to the agent standards files; there is no runtime behavior to test.